### PR TITLE
Fix crash with OptiFine

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/mixin/FusionMixinPlugin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/FusionMixinPlugin.java
@@ -40,7 +40,7 @@ public class FusionMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName){
-        return !(this.isModernFixLoaded || this.isOptiFineLoaded && mixinClassName.endsWith(".TextureAtlasMixin"));
+        return !((this.isModernFixLoaded || this.isOptiFineLoaded) && mixinClassName.endsWith(".TextureAtlasMixin"));
     }
 
     @Override

--- a/src/main/java/com/supermartijn642/fusion/mixin/FusionMixinPlugin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/FusionMixinPlugin.java
@@ -28,7 +28,6 @@ public class FusionMixinPlugin implements IMixinConfigPlugin {
         try{
             MixinService.getService().getBytecodeProvider().getClassNode("optifine.Installer");
             this.isOptiFineLoaded = true;
-            System.out.println("OptiFine found.");
         }catch(Exception ignored){
             this.isOptiFineLoaded = false;
         }

--- a/src/main/java/com/supermartijn642/fusion/mixin/FusionMixinPlugin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/FusionMixinPlugin.java
@@ -15,6 +15,7 @@ import java.util.Set;
 public class FusionMixinPlugin implements IMixinConfigPlugin {
 
     private boolean isModernFixLoaded;
+    private boolean isOptiFineLoaded;
 
     @Override
     public void onLoad(String mixinPackage){
@@ -23,6 +24,13 @@ public class FusionMixinPlugin implements IMixinConfigPlugin {
             this.isModernFixLoaded = true;
         }catch(Exception ignored){
             this.isModernFixLoaded = false;
+        }
+        try{
+            MixinService.getService().getBytecodeProvider().getClassNode("optifine.Installer");
+            this.isOptiFineLoaded = true;
+            System.out.println("OptiFine found.");
+        }catch(Exception ignored){
+            this.isOptiFineLoaded = false;
         }
     }
 
@@ -33,7 +41,7 @@ public class FusionMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName){
-        return !(this.isModernFixLoaded && mixinClassName.endsWith(".TextureAtlasMixin"));
+        return !(this.isModernFixLoaded || this.isOptiFineLoaded && mixinClassName.endsWith(".TextureAtlasMixin"));
     }
 
     @Override
@@ -42,7 +50,7 @@ public class FusionMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public List<String> getMixins(){
-        return this.isModernFixLoaded ?
+        return this.isModernFixLoaded || this.isOptiFineLoaded ?
             Collections.singletonList("modernfix.TextureAtlasMixinModernFix")
             : null;
     }


### PR DESCRIPTION
I can't really explain why finding the lambda in the mixin fails because in OptiFine's source code, it doesn't modify anywhere near the lambda. But, using ModernFix's fix fixes the crash with OptiFine.

![image](https://github.com/SuperMartijn642/Fusion/assets/60985521/0fd5367f-1105-493c-a1cb-0dea50f494b2)