### PR TITLE
Avoid pointless ternary in ConnectingBakedModel

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/model/types/connecting/ConnectingBakedModel.java
+++ b/src/main/java/com/supermartijn642/fusion/model/types/connecting/ConnectingBakedModel.java
@@ -58,7 +58,7 @@ public class ConnectingBakedModel extends WrappedBakedModel {
 
     @Override
     public @NotNull List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @NotNull RandomSource random, @NotNull ModelData modelData, @Nullable RenderType renderType){
-        SurroundingBlockData data = modelData.has(SURROUNDING_BLOCK_DATA_MODEL_PROPERTY) ? modelData.get(SURROUNDING_BLOCK_DATA_MODEL_PROPERTY) : null;
+        SurroundingBlockData data = modelData.get(SURROUNDING_BLOCK_DATA_MODEL_PROPERTY);
         int hashCode = data == null ? 0 : data.hashCode();
 
         // Get the correct cache and quads


### PR DESCRIPTION
`ModelData#get()` already returns `null` if the property doesn't exist, so there isn't a need to call `has` explicitly. Since calling both `has` and `get` requires looking up the property from the underlying map twice, this should *slightly* improve performance of `getQuads` (but I did not profile, and the improvement may be insignificant).

This is just a drive-by PR because I happened to be reading the file and it seemed like an obvious cleanup.