### PR TITLE
Improve performance of WeightedBakedModel model data injector

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/mixin/WeightedBakedModelMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/WeightedBakedModelMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.util.random.WeightedEntry;
 import net.minecraft.util.random.WeightedRandom;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.SingleThreadedRandomSource;
 import net.minecraftforge.client.extensions.IForgeBakedModel;
 import net.minecraftforge.client.model.data.ModelData;
 import org.jetbrains.annotations.NotNull;
@@ -15,32 +16,52 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created 26/10/2023 by SuperMartijn642
  */
 @Mixin(WeightedBakedModel.class)
 public class WeightedBakedModelMixin implements IForgeBakedModel {
-
     @Final
     @Shadow
     private int totalWeight;
     @Final
     @Shadow
     private List<WeightedEntry.Wrapper<BakedModel>> list;
+
     @Unique
-    private final ThreadLocal<RandomSource> RANDOM = ThreadLocal.withInitial(RandomSource::create);
+    private static final ConcurrentHashMap<Class<? extends IForgeBakedModel>, Boolean> MODELS_PRODUCING_DATA = new ConcurrentHashMap<>();
+
+    @Unique
+    private boolean fusion$innerModelProducesData;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void onInit(CallbackInfo ci) {
+        this.fusion$innerModelProducesData = list.stream().anyMatch(w -> w.getData() != null && MODELS_PRODUCING_DATA.computeIfAbsent(w.getData().getClass(), clz -> {
+            try {
+                var method = clz.getMethod("getModelData", BlockAndTintGetter.class, BlockPos.class, BlockState.class, ModelData.class);
+                return method.getDeclaringClass() != IForgeBakedModel.class;
+            } catch(NoSuchMethodException e) {
+                // This should not happen, but if so, assume it does produce data
+                return true;
+            }
+        }));
+    }
 
     @Override
     public @NotNull ModelData getModelData(@NotNull BlockAndTintGetter level, @NotNull BlockPos pos, @NotNull BlockState state, @NotNull ModelData modelData){
-        if(state == null)
+        // Skip expensive computations below if none of the inner models need model data
+        if(state == null || !fusion$innerModelProducesData)
             return modelData;
 
         // Get the seed for the given block position
-        RandomSource randomSource = this.RANDOM.get();
-        randomSource.setSeed(state.getSeed(pos));
+        RandomSource randomSource = new SingleThreadedRandomSource(state.getSeed(pos));
         // Update the model data for the selected sub model
         BakedModel model = WeightedRandom.getWeightedItem(this.list, Math.abs((int)randomSource.nextLong()) % this.totalWeight)
             .map(WeightedEntry.Wrapper::getData).orElse(null);


### PR DESCRIPTION
Fusion injects a `getModelData` implementation into `WeightedBakedModel` so that inner models can still provide model data. Unfortunately, this is not cheap (since it requires looking up a `BlockState`'s seed, reading a thread local, etc) and in most cases is wasteful, as this isn't a standard Forge feature, and therefore the inner model rarely provides any model data anyway. The mixin also stores a `ThreadLocal` instance on every weighted model which is quite wasteful. In my profiling, this accounted for 12% of CPU time on the chunk meshing thread.

![2024-09-02_13-26](https://github.com/user-attachments/assets/ac00c62e-919e-4c07-a0f4-b07ac6e0b069)

This PR mitigates the performance issues with a few changes:

1. At construction time, check if any of the inner models implement `getModelData` and store this in a flag. (This is fast & cheap, models are generally not constructed in hot code).
2. Bail out of `getModelData` immediately if it's known that none of the inner models will provide non-empty model data. This makes the implementation essentially free on any vanilla-constructed weighted model with `SimpleBakedModel`s inside.
3. Replace the `ThreadLocal` random instance with a direct allocation of `SingleThreadedRandomSource`. As a result of 2, we rarely actually reach this part of the code, and so the allocation is no longer hot enough for the thread local to provide any benefit. `SingleThreadedRandomSource` is also faster than the implementation returned by `RandomSource.create`.

Long term, I think it would be more ideal for Fusion to use a custom subclass of `WeightedBakedModel` if it needs support for model data on weighted models.

I've made this PR to the 1.20 branch as it's what I'm using but feel free to cherry-pick; I think the changes should largely apply as-is to anything since at least 1.19.