### PR TITLE
Compatibility with LoliASM's squashBakedQuad feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 //    runtimeOnly "curse.maven:mixin-booter-419286:4459218"
     // Relictium
     compileOnly fg.deobf("curse.maven:relictium-1181652:6103239")
+    // LoliASM
+    compileOnly fg.deobf("curse.maven:loliasm-460609:7267368")
 
     // Just Enough Items
 //    runtimeOnly fg.deobf("curse.maven:jei-238222:${just_enough_items_file}")
@@ -127,7 +129,7 @@ minecraft {
 
 tasks.register('processSources', Sync) {
     from sourceSets.main.java
-    into layout.buildDirectory.dir("/sources")
+    into layout.buildDirectory.dir("sources")
     inputs.property 'version', version
 
     // Replace mod properties in main mod class

--- a/src/main/java/com/supermartijn642/fusion/mixin/BlockModelRendererMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/BlockModelRendererMixin.java
@@ -71,7 +71,7 @@ public class BlockModelRendererMixin {
     )
     private BakedQuad tintQuadAO(BakedQuad quad, IBlockAccess level, IBlockState state, BlockPos pos, BufferBuilder vertexConsumer, List<BakedQuad> quads, float[] arr, BitSet bitSet, BlockModelRenderer.AmbientOcclusionFace occlusion){
         // In case texture has a custom tinting set, replace the original tinting
-        if(quad.tintIndex == 39216){
+        if(quad.getTintIndex() == 39216){
             TextureAtlasSprite sprite = quad.getSprite();
             if(sprite instanceof BaseTextureSprite){
                 BaseTextureData.QuadTinting tinting = ((BaseTextureSprite)sprite).data().getTinting();
@@ -101,7 +101,7 @@ public class BlockModelRendererMixin {
     )
     private BakedQuad tintQuadFlat(BakedQuad quad, IBlockAccess level, IBlockState state, BlockPos pos, int lightmap, boolean recalculateLight, BufferBuilder vertexConsumer){
         // In case texture has a custom tinting set, replace the original tinting
-        if(quad.tintIndex == 39216){
+        if(quad.getTintIndex() == 39216){
             TextureAtlasSprite sprite = quad.getSprite();
             if(sprite instanceof BaseTextureSprite){
                 BaseTextureData.QuadTinting tinting = ((BaseTextureSprite)sprite).data().getTinting();

--- a/src/main/java/com/supermartijn642/fusion/mixin/RenderItemMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/RenderItemMixin.java
@@ -27,7 +27,7 @@ public class RenderItemMixin {
     )
     private void renderQuadList(BufferBuilder vertexConsumer, BakedQuad quad, int color){
         // In case texture has a custom tinting set, replace the original tinting
-        if(quad.tintIndex == 39216){
+        if(quad.getTintIndex() == 39216){
             TextureAtlasSprite sprite = quad.getSprite();
             if(sprite instanceof BaseTextureSprite){
                 BaseTextureData.QuadTinting tinting = ((BaseTextureSprite)sprite).data().getTinting();

--- a/src/main/java/com/supermartijn642/fusion/mixin/forge/LightUtilMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/forge/LightUtilMixin.java
@@ -29,7 +29,7 @@ public class LightUtilMixin {
     )
     private static void putBakedQuad(IVertexConsumer consumer, BakedQuad quad, CallbackInfo ci){
         // In case texture has a custom tinting set, mark the vertex consumer
-        if(quad.tintIndex == 39216){
+        if(quad.getTintIndex() == 39216){
             TextureAtlasSprite sprite = quad.getSprite();
             if(sprite instanceof BaseTextureSprite){
                 BaseTextureData.QuadTinting tinting = ((BaseTextureSprite)sprite).data().getTinting();

--- a/src/main/java/com/supermartijn642/fusion/mixin/vintagium/BlockRendererMixinVintagium.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/vintagium/BlockRendererMixinVintagium.java
@@ -35,7 +35,7 @@ public class BlockRendererMixinVintagium {
     )
     private int[] getBlockTint(int[] colors, IBlockAccess level, IBlockState state, BlockPos pos, ModelVertexSink sink, Vec3d offset, IBlockColor colorProvider, BakedQuad quad, QuadLightData light, ChunkRenderData.Builder renderData){
         // In case texture has a custom tinting set, replace the original tinting
-        if(quad.tintIndex == 39216){
+        if(quad.getTintIndex() == 39216){
             TextureAtlasSprite sprite = quad.getSprite();
             if(sprite instanceof BaseTextureSprite){
                 BaseTextureData.QuadTinting tinting = ((BaseTextureSprite)sprite).data().getTinting();

--- a/src/main/java/com/supermartijn642/fusion/model/types/base/BaseModelQuad.java
+++ b/src/main/java/com/supermartijn642/fusion/model/types/base/BaseModelQuad.java
@@ -7,11 +7,16 @@ import com.supermartijn642.fusion.texture.types.base.BaseTextureSprite;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.common.Loader;
+import zone.rong.loliasm.bakedquad.SupportingBakedQuad;
+import zone.rong.loliasm.config.LoliConfig;
 
 /**
  * Created 06/09/2024 by SuperMartijn642
  */
 public class BaseModelQuad {
+
+    private static final boolean isSquashBakedQuadEnabled = Loader.isModLoaded("loliasm") && LoliConfig.instance.squashBakedQuads;
 
     private final BakedQuad bakedQuad;
     private final TextureType<?> textureType;
@@ -21,7 +26,7 @@ public class BaseModelQuad {
     private final boolean emissive;
 
     public BaseModelQuad(BakedQuad bakedQuad, EnumFacing cullDirection, Integer lightEmission){
-        this.bakedQuad = bakedQuad;
+        BakedQuad quad = bakedQuad;
         this.textureType = SpriteHelper.getTextureType(bakedQuad.getSprite());
         this.cullDirection = cullDirection;
         this.lightEmission = lightEmission;
@@ -31,11 +36,17 @@ public class BaseModelQuad {
             this.renderType = data.getRenderType();
             this.emissive = data.isEmissive();
             if(data.getTinting() != null)
-                bakedQuad.tintIndex = 39216;
+                if(isSquashBakedQuadEnabled) {
+                    quad = new SupportingBakedQuad(quad.getVertexData(), 39216, quad.getFace(),
+                            quad.getSprite(), quad.shouldApplyDiffuseLighting(), quad.getFormat());
+                }else{
+                    bakedQuad.tintIndex = 39216;
+                }
         }else{
             this.renderType = null;
             this.emissive = false;
         }
+        this.bakedQuad = quad;
     }
 
     public BakedQuad bakedQuad(){


### PR DESCRIPTION
- Use `BakedQuad#getTintIndex` whenever possible
- When `LoliASM` is installed and `squashBakedQuad` is enabled, use `SupportingBakedQuad` to use a proper `tintIndex`
- Also fixes a tiny buildscript bug when creating a sources directory