### PR TITLE
Add BiomeTextureType [Feature Request #128]

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/FusionClient.java
+++ b/src/main/java/com/supermartijn642/fusion/FusionClient.java
@@ -40,6 +40,7 @@ public class FusionClient implements ClientModInitializer {
         FusionTextureTypeRegistry.registerTextureType(Identifier.fromNamespaceAndPath("fusion", "scrolling"), DefaultTextureTypes.SCROLLING);
         FusionTextureTypeRegistry.registerTextureType(Identifier.fromNamespaceAndPath("fusion", "random"), DefaultTextureTypes.RANDOM);
         FusionTextureTypeRegistry.registerTextureType(Identifier.fromNamespaceAndPath("fusion", "continuous"), DefaultTextureTypes.CONTINUOUS);
+        FusionTextureTypeRegistry.registerTextureType(Identifier.fromNamespaceAndPath("fusion", "biome"), DefaultTextureTypes.BIOME);
         // Register default model types
         FusionModelTypeRegistry.registerModelType(Identifier.fromNamespaceAndPath("fusion", "unknown"), DefaultModelTypes.UNKNOWN);
         FusionModelTypeRegistry.registerModelType(Identifier.fromNamespaceAndPath("fusion", "vanilla"), DefaultModelTypes.VANILLA);

--- a/src/main/java/com/supermartijn642/fusion/api/texture/DefaultTextureTypes.java
+++ b/src/main/java/com/supermartijn642/fusion/api/texture/DefaultTextureTypes.java
@@ -4,6 +4,7 @@ import com.supermartijn642.fusion.api.model.DefaultModelTypes;
 import com.supermartijn642.fusion.api.texture.data.*;
 import com.supermartijn642.fusion.texture.types.VanillaTextureType;
 import com.supermartijn642.fusion.texture.types.base.BaseTextureType;
+import com.supermartijn642.fusion.texture.types.biome.BiomeTextureType;
 import com.supermartijn642.fusion.texture.types.connecting.ConnectingTextureType;
 import com.supermartijn642.fusion.texture.types.continuous.ContinuousTextureType;
 import com.supermartijn642.fusion.texture.types.random.RandomTextureType;
@@ -45,4 +46,9 @@ public final class DefaultTextureTypes {
      * @see ContinuousTextureData#builder()
      */
     public static final TextureType<ContinuousTextureData> CONTINUOUS = new ContinuousTextureType();
+    /**
+     * Texture type which selects a tile based on the biome the block is in. Should be used in conjunction with {@link DefaultModelTypes#BASE} model type.
+     * @see BiomeTextureData#builder()
+     */
+    public static final TextureType<BiomeTextureData> BIOME = new BiomeTextureType();
 }

--- a/src/main/java/com/supermartijn642/fusion/api/texture/data/BiomeTextureData.java
+++ b/src/main/java/com/supermartijn642/fusion/api/texture/data/BiomeTextureData.java
@@ -1,0 +1,53 @@
+package com.supermartijn642.fusion.api.texture.data;
+
+import com.supermartijn642.fusion.texture.types.biome.BiomeTextureDataBuilderImpl;
+import net.minecraft.resources.Identifier;
+
+import java.util.Map;
+
+public interface BiomeTextureData extends BaseTextureData {
+
+    /**
+     * Creates a builder for biome texture data.
+     */
+    static BiomeTextureData.Builder builder(){
+        return new BiomeTextureDataBuilderImpl();
+    }
+
+    int getRows();
+
+    int getColumns();
+
+    /**
+     * @return the default tile index to use when no biome matches.
+     */
+    int getDefaultTile();
+
+    /**
+     * @return map of biome identifiers to tile indices.
+     */
+    Map<Identifier,Integer> getBiomeTiles();
+
+    interface Builder extends BaseTextureData.Builder<Builder,BiomeTextureData> {
+
+        /**
+         * Sets the number of rows of tiles in the image.
+         */
+        Builder rows(int rows);
+
+        /**
+         * Sets the number of columns of tiles in the image.
+         */
+        Builder columns(int columns);
+
+        /**
+         * Sets the default tile index.
+         */
+        Builder defaultTile(int tile);
+
+        /**
+         * Sets the tile index to use for the given biome.
+         */
+        Builder biomeTile(Identifier biome, int tile);
+    }
+}

--- a/src/main/java/com/supermartijn642/fusion/model/types/base/BaseBakedModel.java
+++ b/src/main/java/com/supermartijn642/fusion/model/types/base/BaseBakedModel.java
@@ -4,6 +4,8 @@ import com.supermartijn642.fusion.FusionClient;
 import com.supermartijn642.fusion.api.texture.DefaultTextureTypes;
 import com.supermartijn642.fusion.api.util.Pair;
 import com.supermartijn642.fusion.model.MutableQuad;
+import com.supermartijn642.fusion.texture.types.biome.BiomeTextureSprite;
+import com.supermartijn642.fusion.texture.types.biome.BiomeTextureType;
 import com.supermartijn642.fusion.texture.types.continuous.ContinuousTextureSprite;
 import com.supermartijn642.fusion.texture.types.continuous.ContinuousTextureType;
 import com.supermartijn642.fusion.texture.types.random.RandomTextureSprite;
@@ -57,8 +59,8 @@ public class BaseBakedModel implements BlockStateModel {
             emitter.cullFace(quad.cullDirection());
             FusionClient.applyMaterialProperties(emitter, hasAmbientOcclusion, quad.renderType(), quad.emissive());
             // Tag quads which need additional processing
-            if(quad.textureType() == DefaultTextureTypes.RANDOM || quad.textureType() == DefaultTextureTypes.CONTINUOUS){
-                int type = quad.textureType() == DefaultTextureTypes.RANDOM ? 2 : 3;
+            if(quad.textureType() == DefaultTextureTypes.RANDOM || quad.textureType() == DefaultTextureTypes.CONTINUOUS || quad.textureType() == DefaultTextureTypes.BIOME){
+                int type = quad.textureType() == DefaultTextureTypes.RANDOM ? 2 : quad.textureType() == DefaultTextureTypes.CONTINUOUS ? 3 : 4;
                 // Give each sprite a unique index
                 int spriteIndex = sprites.computeIfAbsent(quad.bakedQuad().sprite(), o -> sprites.size());
                 // Pack the type and sprite index into the tag
@@ -129,6 +131,12 @@ public class BaseBakedModel implements BlockStateModel {
                     if(type == 3){
                         mutableQuad.set(quad);
                         ContinuousTextureType.processQuad(mutableQuad, pos, quad.nominalFace(), (ContinuousTextureSprite)sprite);
+                        return true;
+                    }
+                    // Handle biome texture type
+                    if(type == 4){
+                        mutableQuad.set(quad);
+                        BiomeTextureType.processQuad(mutableQuad, blockView, pos, quad.nominalFace(), (BiomeTextureSprite)sprite);
                         return true;
                     }
                 }

--- a/src/main/java/com/supermartijn642/fusion/model/types/connecting/ConnectingBakedModel.java
+++ b/src/main/java/com/supermartijn642/fusion/model/types/connecting/ConnectingBakedModel.java
@@ -8,6 +8,8 @@ import com.supermartijn642.fusion.api.predicate.ConnectionPredicate;
 import com.supermartijn642.fusion.api.texture.DefaultTextureTypes;
 import com.supermartijn642.fusion.api.texture.data.ConnectingTextureLayout;
 import com.supermartijn642.fusion.api.util.Pair;
+import com.supermartijn642.fusion.texture.types.biome.BiomeTextureSprite;
+import com.supermartijn642.fusion.texture.types.biome.BiomeTextureType;
 import com.supermartijn642.fusion.texture.types.connecting.ConnectingTextureSprite;
 import com.supermartijn642.fusion.texture.types.connecting.TextureConnections;
 import com.supermartijn642.fusion.texture.types.connecting.layouts.ConnectingTextureLayoutHandler;
@@ -131,8 +133,8 @@ public class ConnectingBakedModel implements BlockStateModel {
                 tag = 1 | (spriteIndex << 4) | (predicateIndex << 12);
             }
             // Tag quads which need additional processing
-            if(quad.textureType() == DefaultTextureTypes.RANDOM || quad.textureType() == DefaultTextureTypes.CONTINUOUS){
-                int type = quad.textureType() == DefaultTextureTypes.RANDOM ? 2 : 3;
+            if(quad.textureType() == DefaultTextureTypes.RANDOM || quad.textureType() == DefaultTextureTypes.CONTINUOUS || quad.textureType() == DefaultTextureTypes.BIOME){
+                int type = quad.textureType() == DefaultTextureTypes.RANDOM ? 2 : quad.textureType() == DefaultTextureTypes.CONTINUOUS ? 3 : 4;
                 // Give each sprite a unique index
                 int spriteIndex = sprites.computeIfAbsent(quad.bakedQuad().sprite(), o -> sprites.size());
                 // Pack the type and sprite index into the tag
@@ -279,6 +281,13 @@ public class ConnectingBakedModel implements BlockStateModel {
                             mutableQuad.set(quad);
                             mutableQuad.resetPermutation();
                             ContinuousTextureType.processQuad(mutableQuad, pos, quad.nominalFace(), (ContinuousTextureSprite)sprite);
+                            return true;
+                        }
+                        // Handle biome texture type
+                        if(type == 4){
+                            mutableQuad.set(quad);
+                            mutableQuad.resetPermutation();
+                            BiomeTextureType.processQuad(mutableQuad, blockView, pos, quad.nominalFace(), (BiomeTextureSprite)sprite);
                             return true;
                         }
                     }

--- a/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureDataBuilderImpl.java
+++ b/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureDataBuilderImpl.java
@@ -1,0 +1,83 @@
+package com.supermartijn642.fusion.texture.types.biome;
+
+import com.supermartijn642.fusion.api.texture.data.BaseTextureData;
+import com.supermartijn642.fusion.api.texture.data.BiomeTextureData;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BiomeTextureDataBuilderImpl implements BiomeTextureData.Builder {
+
+    private BaseTextureData.RenderType renderType;
+    private boolean emissive = false;
+    private BaseTextureData.QuadTinting tinting;
+    private int rows = 1, columns = 1;
+    private int defaultTile = 0;
+    private final Map<Identifier,Integer> biomeTiles = new HashMap<>();
+
+    @Override
+    public BiomeTextureDataBuilderImpl renderType(@Nullable BaseTextureData.RenderType renderType){
+        this.renderType = renderType;
+        return this;
+    }
+
+    @Override
+    public BiomeTextureDataBuilderImpl emissive(boolean emissive){
+        this.emissive = emissive;
+        return this;
+    }
+
+    @Override
+    public BiomeTextureDataBuilderImpl tinting(BaseTextureData.@Nullable QuadTinting tinting){
+        this.tinting = tinting;
+        return this;
+    }
+
+    @Override
+    public BiomeTextureData.Builder rows(int rows){
+        if(rows < 1 || rows > 10)
+            throw new IllegalArgumentException("rows must be between 1 and 10");
+        this.rows = rows;
+        return this;
+    }
+
+    @Override
+    public BiomeTextureData.Builder columns(int columns){
+        if(columns < 1 || columns > 10)
+            throw new IllegalArgumentException("columns must be between 1 and 10");
+        this.columns = columns;
+        return this;
+    }
+
+    @Override
+    public BiomeTextureData.Builder defaultTile(int tile){
+        if(tile < 0)
+            throw new IllegalArgumentException("default tile must be non-negative");
+        this.defaultTile = tile;
+        return this;
+    }
+
+    @Override
+    public BiomeTextureData.Builder biomeTile(Identifier biome, int tile){
+        if(biome == null)
+            throw new IllegalArgumentException("biome cannot be null");
+        if(tile < 0)
+            throw new IllegalArgumentException("tile must be non-negative");
+        this.biomeTiles.put(biome, tile);
+        return this;
+    }
+
+    @Override
+    public BiomeTextureData build(){
+        int max = this.rows * this.columns;
+        if(this.defaultTile >= max)
+            throw new IllegalArgumentException("default tile cannot be greater than or equal to rows * columns!");
+        for(Map.Entry<Identifier,Integer> entry : this.biomeTiles.entrySet()){
+            if(entry.getValue() >= max)
+                throw new IllegalArgumentException("tile index for biome '" + entry.getKey() + "' cannot be greater than or equal to rows * columns!");
+        }
+        return new BiomeTextureDataImpl(this.renderType, this.emissive, this.tinting, this.rows, this.columns, this.defaultTile, this.biomeTiles);
+    }
+}

--- a/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureDataImpl.java
+++ b/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureDataImpl.java
@@ -1,0 +1,43 @@
+package com.supermartijn642.fusion.texture.types.biome;
+
+import com.supermartijn642.fusion.api.texture.data.BiomeTextureData;
+import com.supermartijn642.fusion.texture.types.base.BaseTextureDataImpl;
+import net.minecraft.resources.Identifier;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class BiomeTextureDataImpl extends BaseTextureDataImpl implements BiomeTextureData {
+
+    private final int rows, columns;
+    private final int defaultTile;
+    private final Map<Identifier,Integer> biomeTiles;
+
+    public BiomeTextureDataImpl(RenderType renderType, boolean emissive, QuadTinting tinting, int rows, int columns, int defaultTile, Map<Identifier,Integer> biomeTiles){
+        super(renderType, emissive, tinting);
+        this.rows = rows;
+        this.columns = columns;
+        this.defaultTile = defaultTile;
+        this.biomeTiles = Collections.unmodifiableMap(biomeTiles);
+    }
+
+    @Override
+    public int getRows(){
+        return this.rows;
+    }
+
+    @Override
+    public int getColumns(){
+        return this.columns;
+    }
+
+    @Override
+    public int getDefaultTile(){
+        return this.defaultTile;
+    }
+
+    @Override
+    public Map<Identifier,Integer> getBiomeTiles(){
+        return this.biomeTiles;
+    }
+}

--- a/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureSprite.java
+++ b/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureSprite.java
@@ -1,0 +1,30 @@
+package com.supermartijn642.fusion.texture.types.biome;
+
+import com.supermartijn642.fusion.api.texture.data.BiomeTextureData;
+import com.supermartijn642.fusion.texture.types.base.BaseTextureSprite;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+public class BiomeTextureSprite extends BaseTextureSprite {
+
+    protected BiomeTextureSprite(TextureAtlasSprite original, BiomeTextureData data){
+        super(
+            original.atlasLocation(),
+            original.contents(),
+            1,
+            1,
+            original.getX(),
+            original.getY(),
+            original.padding,
+            data
+        );
+        this.u0 = original.u0;
+        this.u1 = original.u1;
+        this.v0 = original.v0;
+        this.v1 = original.v1;
+    }
+
+    @Override
+    public BiomeTextureData data(){
+        return (BiomeTextureData)super.data();
+    }
+}

--- a/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureType.java
+++ b/src/main/java/com/supermartijn642/fusion/texture/types/biome/BiomeTextureType.java
@@ -1,0 +1,198 @@
+package com.supermartijn642.fusion.texture.types.biome;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.supermartijn642.fusion.api.texture.DefaultTextureTypes;
+import com.supermartijn642.fusion.api.texture.SpriteCreationContext;
+import com.supermartijn642.fusion.api.texture.SpritePreparationContext;
+import com.supermartijn642.fusion.api.texture.TextureErrorException;
+import com.supermartijn642.fusion.api.texture.TextureType;
+import com.supermartijn642.fusion.api.texture.data.BaseTextureData;
+import com.supermartijn642.fusion.api.texture.data.BiomeTextureData;
+import com.supermartijn642.fusion.api.util.Pair;
+import com.supermartijn642.fusion.model.MutableQuad;
+import com.supermartijn642.fusion.util.IdentifierUtil;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.metadata.animation.AnimationMetadataSection;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.biome.Biome;
+
+import java.util.Comparator;
+import java.util.Map;
+
+public class BiomeTextureType implements TextureType<BiomeTextureData> {
+
+    @Override
+    public BiomeTextureData deserialize(JsonObject json) throws JsonParseException{
+        // Deserialize base properties
+        BaseTextureData base = DefaultTextureTypes.BASE.deserialize(json);
+        // Copy base properties
+        BiomeTextureData.Builder builder = BiomeTextureData.builder();
+        builder.renderType(base.getRenderType());
+        builder.emissive(base.isEmissive());
+        builder.tinting(base.getTinting());
+        // Rows
+        int rows = 1;
+        if(json.has("rows")){
+            if(!json.get("rows").isJsonPrimitive() || !json.getAsJsonPrimitive("rows").isNumber())
+                throw new JsonParseException("Property 'rows' must be a number!");
+            rows = json.get("rows").getAsInt();
+            if(rows < 1 || rows > 10)
+                throw new JsonParseException("Property 'rows' must be a number between 1 and 10!");
+            builder.rows(rows);
+        }
+        // Columns
+        int columns = 1;
+        if(json.has("columns")){
+            if(!json.get("columns").isJsonPrimitive() || !json.getAsJsonPrimitive("columns").isNumber())
+                throw new JsonParseException("Property 'columns' must be a number!");
+            columns = json.get("columns").getAsInt();
+            if(columns < 1 || columns > 10)
+                throw new JsonParseException("Property 'columns' must be a number between 1 and 10!");
+            builder.columns(columns);
+        }
+        // Default tile
+        if(json.has("default")){
+            builder.defaultTile(parseTileIndex(json.get("default"), rows, columns, "default"));
+        }
+        // Biomes mapping
+        if(json.has("biomes")){
+            if(!json.get("biomes").isJsonObject())
+                throw new JsonParseException("Property 'biomes' must be an object!");
+            for(Map.Entry<String,JsonElement> entry : json.getAsJsonObject("biomes").entrySet()){
+                String key = entry.getKey();
+                if(!IdentifierUtil.isValidIdentifier(key))
+                    throw new JsonParseException("Biome entries must be a valid identifier, not '" + key + "'!");
+                int tile = parseTileIndex(entry.getValue(), rows, columns, "biomes." + key);
+                builder.biomeTile(Identifier.parse(key), tile);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public JsonObject serialize(BiomeTextureData data){
+        // Serialize base properties
+        JsonObject json = DefaultTextureTypes.BASE.serialize(data);
+        // Rows
+        if(data.getRows() != 1)
+            json.addProperty("rows", data.getRows());
+        // Columns
+        if(data.getColumns() != 1)
+            json.addProperty("columns", data.getColumns());
+        // Default tile
+        if(data.getDefaultTile() != 0)
+            json.addProperty("default", data.getDefaultTile());
+        // Biomes mapping
+        if(!data.getBiomeTiles().isEmpty()){
+            JsonObject biomes = new JsonObject();
+            data.getBiomeTiles().entrySet().stream()
+                .sorted(Comparator.comparing(entry -> entry.getKey().toString()))
+                .forEach(entry -> biomes.addProperty(entry.getKey().toString(), entry.getValue()));
+            json.add("biomes", biomes);
+        }
+        return json;
+    }
+
+    @Override
+    public Pair<Integer,Integer> getFrameSize(SpritePreparationContext context, BiomeTextureData data){
+        // Handle animation metadata
+        if(context.getAnimationMetadata() != null){
+            AnimationMetadataSection animation = context.getAnimationMetadata();
+            Pair<Integer,Integer> frameSize;
+            if(animation.frameWidth().isPresent() && animation.frameHeight().isPresent())
+                frameSize = Pair.of(animation.frameWidth().get(), animation.frameHeight().get());
+            else if(animation.frameWidth().isPresent())
+                frameSize = Pair.of(animation.frameWidth().get(), context.getTextureHeight());
+            else if(animation.frameHeight().isPresent())
+                frameSize = Pair.of(context.getTextureWidth(), animation.frameHeight().get());
+            else{
+                // Use the expected aspect ratio for the layout
+                int height = Math.min(context.getTextureWidth() * data.getRows() / data.getColumns(), context.getTextureHeight());
+                //noinspection SuspiciousNameCombination
+                frameSize = Pair.of(context.getTextureWidth(), height);
+            }
+            // Do vanilla frame size check
+            if(!Mth.isMultipleOf(context.getTextureWidth(), frameSize.left())
+                || !Mth.isMultipleOf(context.getTextureHeight(), frameSize.right()))
+                throw new TextureErrorException("Image size " + context.getTextureWidth() + "x" + context.getTextureHeight() + " is not a multiple of frame size " + frameSize.left() + "x" + frameSize.right() + "!");
+            return frameSize;
+        }
+
+        // Verify aspect ratio corresponds to row/column count
+        int width = context.getTextureWidth();
+        int height = context.getTextureHeight();
+        if(width * data.getRows() / data.getColumns() != height)
+            throw new TextureErrorException("Image aspect ratio does not match row/column aspect ratio!");
+        //noinspection SuspiciousNameCombination
+        return Pair.of(width, height);
+    }
+
+    @Override
+    public TextureAtlasSprite createSprite(SpriteCreationContext context, BiomeTextureData data){
+        TextureAtlasSprite sprite = context.createOriginalSprite();
+        sprite.u1 = sprite.u0 + (sprite.u1 - sprite.u0) / data.getColumns();
+        sprite.v1 = sprite.v0 + (sprite.v1 - sprite.v0) / data.getRows();
+        return new BiomeTextureSprite(sprite, data);
+    }
+
+    public static void processQuad(MutableQuad quad, BlockAndTintGetter blockView, BlockPos pos, Direction side, BiomeTextureSprite sprite){
+        if(side == null)
+            return;
+        BiomeTextureData data = sprite.data();
+        int tile = data.getDefaultTile();
+        if(blockView != null && pos != null){
+            Holder<Biome> biome = blockView.getBiomeFabric(pos);
+            if(biome != null && biome.isBound() && biome.unwrapKey().isPresent()){
+                Identifier id = biome.unwrapKey().get().identifier();
+                Integer biomeTile = data.getBiomeTiles().get(id);
+                if(biomeTile != null)
+                    tile = biomeTile;
+            }
+        }
+        int x = tile % data.getColumns();
+        int y = tile / data.getColumns();
+        if(x > 0 || y > 0){
+            float width = sprite.getU1() - sprite.getU0();
+            float height = sprite.getV1() - sprite.getV0();
+            for(int i = 0; i < 4; i++){
+                quad.uv(
+                    i,
+                    quad.u(i) + x * width,
+                    quad.v(i) + y * height
+                );
+            }
+        }
+    }
+
+    private static int parseTileIndex(JsonElement element, int rows, int columns, String name){
+        int max = rows * columns;
+        if(element.isJsonPrimitive() && element.getAsJsonPrimitive().isNumber()){
+            int index = element.getAsInt();
+            if(index < 0 || index >= max)
+                throw new JsonParseException("Tile index for '" + name + "' must be between 0 and " + (max - 1) + "!");
+            return index;
+        }
+        if(element.isJsonArray()){
+            JsonArray array = element.getAsJsonArray();
+            if(array.size() != 2)
+                throw new JsonParseException("Tile coordinates for '" + name + "' must be an array of two numbers!");
+            if(!array.get(0).isJsonPrimitive() || !array.get(0).getAsJsonPrimitive().isNumber()
+                || !array.get(1).isJsonPrimitive() || !array.get(1).getAsJsonPrimitive().isNumber())
+                throw new JsonParseException("Tile coordinates for '" + name + "' must be an array of two numbers!");
+            int x = array.get(0).getAsInt();
+            int y = array.get(1).getAsInt();
+            if(x < 0 || x >= columns || y < 0 || y >= rows)
+                throw new JsonParseException("Tile coordinates for '" + name + "' must be within the bounds of the grid!");
+            return y * columns + x;
+        }
+        throw new JsonParseException("Tile for '" + name + "' must be a number or an array of two numbers!");
+    }
+}


### PR DESCRIPTION
A friend of mine really wanted this Optifine feature for Fabric. But apparently there wasn't an alternative yet, and this mod came closest to it. Since the feature had been requested several times and it seemed easy to add a new texture type (this is basically a copy of the RandomTextureType), I went ahead and did it.

Example MCMETA file:
stone.png.mcmeta
```
{
  "fusion": {
    "type": "biome",
    "rows": 2,
    "columns": 2,
    "default": 0,
    "biomes": {
      "minecraft:plains": 0,
      "minecraft:forest": 1,
      "minecraft:river": [0, 1],
      "minecraft:savanna": [1, 1]
    }
  }
}
```

It works as you can see here:
Oak Leaves to -> Acacia/Birch Leaves in Forest/Plains biome
<img width="3840" height="2126" alt="2026-03-14_23 04 20" src="https://github.com/user-attachments/assets/a123da4f-6892-46d6-b611-627aca3d1ff1" />
Stone to -> random other textures in various biomes:
<img width="3840" height="2126" alt="2026-03-14_22 18 31" src="https://github.com/user-attachments/assets/523cf02c-7b95-48bb-b269-1b65542610a4" />

But I've also noticed that lines between some blocks can appear, and I'm not sure if it's my fault or the mod's. So I could use some help here (hard to see if not zoomed in):
<img width="3840" height="2126" alt="2026-03-14_22 17 27" src="https://github.com/user-attachments/assets/5b46c9b2-8b85-4846-a6b2-09f25f1b0fb5" />
<img width="3840" height="2126" alt="2026-03-14_22 17 39" src="https://github.com/user-attachments/assets/64a4692e-5f67-4f16-b02c-d5c14c60fc25" />

I'm not sure what the guidelines are here for pull requests, and I rarely create some in general, but I hope this is okay.