### PR TITLE
Fix: clear breaking overlay state after rendering

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/FusionClient.java
+++ b/src/main/java/com/supermartijn642/fusion/FusionClient.java
@@ -13,6 +13,7 @@ import com.supermartijn642.fusion.model.types.connecting.predicates.*;
 import com.supermartijn642.fusion.util.IdentifierUtil;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.Unit;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.neoforge.client.event.ModelEvent;
@@ -29,7 +30,7 @@ public class FusionClient {
 
     public static final Logger LOGGER = LoggerFactory.getLogger("fusion");
 
-    public static final ThreadLocal<Boolean> IS_RENDERING_BREAKING_OVERLAY = new ThreadLocal<>();
+    public static final ThreadLocal<Unit> IS_RENDERING_BREAKING_OVERLAY = new ThreadLocal<>();
 
     public static void init(){
         // Register default texture types

--- a/src/main/java/com/supermartijn642/fusion/mixin/BlockRenderDispatcherMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/BlockRenderDispatcherMixin.java
@@ -2,6 +2,7 @@ package com.supermartijn642.fusion.mixin;
 
 import com.supermartijn642.fusion.FusionClient;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.util.Unit;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,7 +19,7 @@ public class BlockRenderDispatcherMixin {
         at = @At("HEAD")
     )
     private void renderBreakingTextureHead(CallbackInfo ci){
-        FusionClient.IS_RENDERING_BREAKING_OVERLAY.set(true);
+        FusionClient.IS_RENDERING_BREAKING_OVERLAY.set(Unit.INSTANCE);
     }
 
     @Inject(
@@ -26,6 +27,6 @@ public class BlockRenderDispatcherMixin {
         at = @At("TAIL")
     )
     private void renderBreakingTextureTail(CallbackInfo ci){
-        FusionClient.IS_RENDERING_BREAKING_OVERLAY.set(false);
+        FusionClient.IS_RENDERING_BREAKING_OVERLAY.remove();
     }
 }


### PR DESCRIPTION
Once the breaking overlay has been rendered once, any chunk rebuild on the main thread will be considered to be part of a breaking overlay.

Seems to affect all versions that include the `show_breaking_overlay` property.
