### PR TITLE
[1.21.9-10] Fix type error in NamedRenderTypeManagerMixin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ java_dependency=>=21
 resource_pack_format=69
 
 # Forge
-forge_version=59.0.0
-forge_dependency=[59.0.0,)
+forge_version=59.0.2
+forge_dependency=[59.0.2,)
 javafml_dependency=[59,)
 
 # Mixin

--- a/src/main/java/com/supermartijn642/fusion/mixin/forge/NamedRenderTypeManagerMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/forge/NamedRenderTypeManagerMixin.java
@@ -1,6 +1,5 @@
 package com.supermartijn642.fusion.mixin.forge;
 
-import com.google.common.collect.ImmutableMap;
 import com.supermartijn642.fusion.util.ForgeNamedRenderTypeGroupHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.NamedRenderTypeManager;
@@ -10,6 +9,8 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
 
 /**
  * Created 07/06/2026 by SuperMartijn642

--- a/src/main/java/com/supermartijn642/fusion/mixin/forge/NamedRenderTypeManagerMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/forge/NamedRenderTypeManagerMixin.java
@@ -23,7 +23,7 @@ public class NamedRenderTypeManagerMixin {
      */
 
     @Shadow(remap = false)
-    private static ImmutableMap<ResourceLocation,RenderTypeGroup> RENDER_TYPES;
+    private static Map<ResourceLocation,RenderTypeGroup> RENDER_TYPES;
 
     @Inject(
         method = "init",

--- a/src/main/java/com/supermartijn642/fusion/util/ForgeNamedRenderTypeGroupHelper.java
+++ b/src/main/java/com/supermartijn642/fusion/util/ForgeNamedRenderTypeGroupHelper.java
@@ -1,6 +1,5 @@
 package com.supermartijn642.fusion.util;
 
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.RenderTypeGroup;
 

--- a/src/main/java/com/supermartijn642/fusion/util/ForgeNamedRenderTypeGroupHelper.java
+++ b/src/main/java/com/supermartijn642/fusion/util/ForgeNamedRenderTypeGroupHelper.java
@@ -15,7 +15,7 @@ public class ForgeNamedRenderTypeGroupHelper {
 
     private static Map<RenderTypeGroup,ResourceLocation> RENDER_TYPE_GROUPS = Map.of();
 
-    public static void updateMappings(ImmutableMap<ResourceLocation,RenderTypeGroup> renderTypes){
+    public static void updateMappings(Map<ResourceLocation,RenderTypeGroup> renderTypes){
         // Sort identifiers, so behavior is consistent
         List<ResourceLocation> identifiers = new ArrayList<>(renderTypes.keySet());
         identifiers.sort(Comparator.comparing(ResourceLocation::toString));


### PR DESCRIPTION
Forge 59.0.2 changed the underlying datatype to `Map` rather than `ImmutableMap`, breaking your mixin. It seemed easier to just make a PR to fix this rather than bothering with an issue.

To be honest it would probably be better to build against 1.21.10 recommended and mark 59.0.2 as the minimum required, though I didn't do that change. Or just use a monitor level event listener and build the map via reflection without a mixin, either or. I can do it if you'd like.