### PR TITLE
[1.21.4] Enable Jar-in-Jar so MixinExtras is actually bundled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,15 +77,9 @@ processResources {
     rename "^icon.png\$", "${mod_id}.png"
 }
 
-// Embed the dependencies declared in the 'jarJar' configuration, i.e. MixinExtras.
-// Without this, the jarJar(...) dependency declaration above has no effect and the
-// published jar contains no META-INF/jarjar entries.
+// Enable jar-in-jar
 jarJar.enable()
-
-// The jarJar task is the one that carries the embedded dependencies, so make it the
-// primary artifact and keep the published file name unchanged.
 tasks.named("jarJar") { archiveClassifier = "" }
-tasks.named("jar") { archiveClassifier = "slim" }
 tasks.named("assemble") { dependsOn(tasks.jarJar) }
 
 minecraft {

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,17 @@ processResources {
     rename "^icon.png\$", "${mod_id}.png"
 }
 
+// Embed the dependencies declared in the 'jarJar' configuration, i.e. MixinExtras.
+// Without this, the jarJar(...) dependency declaration above has no effect and the
+// published jar contains no META-INF/jarjar entries.
+jarJar.enable()
+
+// The jarJar task is the one that carries the embedded dependencies, so make it the
+// primary artifact and keep the published file name unchanged.
+tasks.named("jarJar") { archiveClassifier = "" }
+tasks.named("jar") { archiveClassifier = "slim" }
+tasks.named("assemble") { dependsOn(tasks.jarJar) }
+
 minecraft {
     mappings channel: "official", version: minecraft_version
 
@@ -164,7 +175,7 @@ tasks.configureEach {
 }
 
 publishMods {
-    file = jar.archiveFile
+    file = tasks.jarJar.archiveFile
     displayName = "${mod_name} ${mod_version} for Forge ${minecraft_suffix.substring(2)}"
     version = project.version
     //noinspection UnnecessaryQualifiedReference


### PR DESCRIPTION
The Forge build declares a Jar-in-Jar dependency on MixinExtras:

```gradle
implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.5.3")) {
    jarJar.ranged(it, "[0.5.3,)")
}
```

but `jarJar.enable()` is never called, and per the ForgeGradle documentation Jar-in-Jar
"is a completely optional system which can be enabled using `jarJar#enable`". The result is
that the declaration has no effect: the published jar contains no `META-INF/jarjar` entries,
MixinExtras is absent at runtime, and every mixin that relies on it fails to apply.

Forge only began shipping MixinExtras itself in **60.0.16** ("Introduce MixinExtras as an
included, optional dependency", #10709), which is Minecraft 1.21.10. So on 1.21.4, running
Forge 54, it still has to be bundled by the mod. That also explains why the `forge-1.21.11`
and `forge-26.x` branches do not declare it and are unaffected by this particular problem.

## Symptoms

On Forge 1.21.4 the game fails to start, with:

```
Error loading class: com/llamalad7/mixinextras/sugar/ref/LocalRef
(java.lang.ClassNotFoundException: com.llamalad7.mixinextras.sugar.ref.LocalRef)
```

On 1.21.1 the same root cause surfaces differently, as a confusing signature mismatch on
`PackMixin`, because without MixinExtras the `@Local PackResources` sugar parameter is never
stripped from the handler and Mixin compares the raw descriptor against the target:

```
@ModifyArg injector ...Pack::addFusionOverrideOverlay targets a method with an invalid signature
  expected (Ljava/util/List;Lnet/minecraft/server/packs/PackResources;)
```

That "expected" descriptor is exactly `addFusionOverrideOverlay`'s own signature including the
sugar parameter.

## Changes

* `jarJar.enable()`, which is the actual fix.
* Enabling Jar-in-Jar moves the shippable content to the `jarJar` task, whose default classifier
  is `all`, so the classifiers are swapped over to keep the released file name exactly as it is
  today. The plain jar becomes `slim`.
* `assemble` is made to depend on `jarJar`, since enabling it does not wire it into the build.
* `publishMods` points at the `jarJar` artifact. Note this has to be `tasks.jarJar.archiveFile`,
  because at project scope `jarJar` resolves to `JarJarProjectExtension` rather than the task.

The `MixinConfigs` manifest attribute is preserved, since MixinGradle's `addMixinsToJarJar` task
already applies it to the Jar-in-Jar artifact.

## Testing

Built locally and tested in game on Minecraft 1.21.4 with Forge 54.1.16, using a connected and
emissive ore resource pack. The game reaches the main menu and loads a world with no errors, and
the log now shows:

```
Found mod file mixinextras-forge-0.5.3.jar of type GAMELIBRARY with provider ...JarInJarDependencyLocator
Initializing MixinExtras via com.llamalad7.mixinextras.service.MixinExtrasServiceImpl(version=0.5.3).
```

Connected textures and emissive textures both render correctly.

## Other affected branches

The same Jar-in-Jar problem is present on `forge-1.21`, `forge-1.21.2`, `forge-1.21.5`,
`forge-1.21.6` and `forge-1.21.9`. All five declare the same `mixinextras-forge:0.5.3` dependency
without calling `jarJar.enable()`, and all five publish `jar.archiveFile`. I reproduced the startup
crash on 1.21.1, 1.21.5, 1.21.6 and 1.21.9 before patching, each showing the same missing
`LocalRef` class.

Since a pull request targets a single branch, I have opened one against each. On `forge-1.21` and
`forge-1.21.2` the patch is byte for byte identical to this one. On `forge-1.21.5`, `forge-1.21.6`
and `forge-1.21.9` this fix alone is not enough, because it uncovers two further crashes that were
previously unreachable, so those pull requests carry two additional commits. There is a separate
one for `forge-1.21.11`, which does not need this Jar-in-Jar change at all.

Please feel free to close any of them and cherry-pick instead if that is easier for you.

Separately, the `forge-1.21.11` branch has two different problems that are unrelated to this one.
I will report those on their own rather than mixing them in here.