### PR TITLE
[1.21] Enable Jar-in-Jar so MixinExtras is actually bundled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,17 @@ processResources {
     rename "^icon.png\$", "${mod_id}.png"
 }
 
+// Embed the dependencies declared in the 'jarJar' configuration, i.e. MixinExtras.
+// Without this, the jarJar(...) dependency declaration above has no effect and the
+// published jar contains no META-INF/jarjar entries.
+jarJar.enable()
+
+// The jarJar task is the one that carries the embedded dependencies, so make it the
+// primary artifact and keep the published file name unchanged.
+tasks.named("jarJar") { archiveClassifier = "" }
+tasks.named("jar") { archiveClassifier = "slim" }
+tasks.named("assemble") { dependsOn(tasks.jarJar) }
+
 minecraft {
     mappings channel: "official", version: minecraft_version
 
@@ -164,7 +175,7 @@ tasks.configureEach {
 }
 
 publishMods {
-    file = jar.archiveFile
+    file = tasks.jarJar.archiveFile
     displayName = "${mod_name} ${mod_version} for Forge ${minecraft_suffix.substring(2)}"
     version = project.version
     //noinspection UnnecessaryQualifiedReference


### PR DESCRIPTION
Same fix as #285, applied to this branch. The diff is byte for byte identical.

The Forge build declares a Jar-in-Jar dependency on MixinExtras but never calls `jarJar.enable()`,
which per the ForgeGradle documentation is what actually turns Jar-in-Jar on. The published jar
therefore contains no `META-INF/jarjar` entries, MixinExtras is missing at runtime, and every
mixin that relies on it fails to apply. The game does not reach the main menu.

Forge only began shipping MixinExtras itself in **60.0.16** ("Introduce MixinExtras as an included,
optional dependency", #10709), which is Minecraft 1.21.10, so every branch below that has to bundle
it. The `forge-1.21.11` and `forge-26.x` branches are unaffected and correctly do not declare it.

## Changes

* `jarJar.enable()`, which is the actual fix.
* The `jarJar` task takes the empty classifier and the plain jar becomes `slim`, so the released
  file name is unchanged.
* `assemble` is made to depend on `jarJar`, since enabling it does not wire it into the build.
* `publishMods` points at `tasks.jarJar.archiveFile`. It has to be the `tasks.` form, because at
  project scope `jarJar` resolves to `JarJarProjectExtension` rather than the task.

The `MixinConfigs` manifest attribute is preserved by MixinGradle's existing `addMixinsToJarJar`
task.

## Testing

Built and tested in game on Minecraft 1.21.1, using a connected and emissive ore resource pack. The
game reaches the main menu and loads a world with no errors, and the log shows MixinExtras being
picked up by the Jar-in-Jar locator and initialising.