### PR TITLE
[1.21.5] Fix three startup crashes on Forge

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/mixin/ModelBlockRendererMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/ModelBlockRendererMixin.java
@@ -27,7 +27,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 public class ModelBlockRendererMixin {
 
     @ModifyExpressionValue(
-        method = "tesselateBlock(Lnet/minecraft/world/level/BlockAndTintGetter;Ljava/util/List;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Ljava/util/function/Function;ZI)V",
+        method = "tesselateBlock(Lnet/minecraft/world/level/BlockAndTintGetter;Ljava/util/List;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZI)V",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/block/state/BlockState;getOffset(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/Vec3;"

--- a/src/main/java/com/supermartijn642/fusion/mixin/SectionCompilerMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/SectionCompilerMixin.java
@@ -45,7 +45,7 @@ public class SectionCompilerMixin {
     }
 
     @ModifyExpressionValue(
-        method = "compile(Lnet/minecraft/core/SectionPos;Lnet/minecraft/client/renderer/chunk/RenderSectionRegion;Lcom/mojang/blaze3d/vertex/VertexSorting;Lnet/minecraft/client/renderer/SectionBufferBuilderPack;Ljava/util/List;)Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;",
+        method = "compile(Lnet/minecraft/core/SectionPos;Lnet/minecraft/client/renderer/chunk/RenderChunkRegion;Lcom/mojang/blaze3d/vertex/VertexSorting;Lnet/minecraft/client/renderer/SectionBufferBuilderPack;)Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;getBlockModel(Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/client/renderer/block/model/BlockStateModel;"


### PR DESCRIPTION
The Forge build of this branch cannot start. There are three separate causes, each of which was
hidden behind the previous one, so they only became visible one at a time. Commit by commit:

## 1. MixinExtras is declared for Jar-in-Jar but never bundled

Same issue as #<NUM>. The build declares `jarJar("io.github.llamalad7:mixinextras-forge:0.5.3")`
but never calls `jarJar.enable()`, which per the ForgeGradle documentation is what actually turns
Jar-in-Jar on. The published jar contains no `META-INF/jarjar` entries, so MixinExtras is missing
at runtime and every mixin using it fails:

```
Error loading class: com/llamalad7/mixinextras/sugar/ref/LocalRef
(java.lang.ClassNotFoundException: com.llamalad7.mixinextras.sugar.ref.LocalRef)
```

Forge only began shipping MixinExtras itself in 60.0.16 ("Introduce MixinExtras as an included,
optional dependency", #10709), which is Minecraft 1.21.10, so this branch has to bundle it.

Enabling Jar-in-Jar moves the shippable artifact to the `jarJar` task, so that task takes the empty
classifier, the plain jar becomes `slim`, `assemble` is made to depend on it, and `publishMods`
points at it. This keeps the released file name unchanged. Note the `publishMods` line has to read
`tasks.jarJar.archiveFile`, because at project scope `jarJar` resolves to `JarJarProjectExtension`
rather than the task.

## 2. ModelBlockRendererMixin targets the NeoForge signature

With MixinExtras present, startup gets further and then fails here:

```
Critical injection failure: @ModifyExpressionValue annotation on modifyRandomOffset
could not find any targets matching 'tesselateBlock(...Lcom/mojang/blaze3d/vertex/PoseStack;
Ljava/util/function/Function;ZI)V' in net/minecraft/client/renderer/block/ModelBlockRenderer
```

Forge patches that method to take a `VertexConsumer` where vanilla and NeoForge take a `Function`.
Verified with javap against the mapped Forge jars for 1.21.5, 1.21.7, 1.21.9 and 1.21.11, which all
declare:

```
tesselateBlock(BlockAndTintGetter, List, BlockState, BlockPos, PoseStack, VertexConsumer, boolean, int)
```

The `forge-1.21`, `forge-1.21.2` and `forge-1.21.4` branches carry a Forge specific descriptor here.
From `forge-1.21.5` onwards this file is identical to the one on the matching NeoForge branch, so
the adaptation looks like it was simply lost when the method was rewritten upstream.

## 3. SectionCompilerMixin targets a parameter Forge does not have

Past the previous two, the game reaches world loading and then fails here:

```
Critical injection failure: @ModifyExpressionValue annotation on collectModelsByOffset
could not find any targets matching 'compile(...Lnet/minecraft/client/renderer/
SectionBufferBuilderPack;Ljava/util/List;)Lnet/minecraft/client/renderer/chunk/
SectionCompiler$Results;' in net/minecraft/client/renderer/chunk/SectionCompiler
```

Forge's `compile` has no trailing `List` parameter. The descriptor in the fixed version is taken
verbatim from javap against the mapped Forge jar for this branch.

This file is already Forge specific in its body, since it imports
`net.minecraftforge.client.model.data.ModelData`, so only the descriptor string appears to have
been carried over.

The handler's `@Local` bindings are unaffected, which I checked against the local variable table of
Forge's method rather than assuming: the `List<BlockModelPart>` it captures exists as a local
variable rather than a parameter, and the `BlockPos` ordinal 2 and the two `Map` ordinals are
unchanged by dropping a `List` parameter.

## Testing

Built and tested in game on Minecraft 1.21.5 with a connected and emissive ore resource pack. The
game reaches the main menu, loads a world and renders correctly, with no errors in the log.

To sanity check that these descriptors were not simply guessed, I also ran every hardcoded mixin
descriptor on this branch against the mapped Forge jar and compared the result with `forge-1.21.4`,
which works in game and therefore acts as a control. After these commits the only remaining
differences are ones that `forge-1.21.4` reports too, and which are artifacts of the check rather
than real problems, namely inherited members such as `BlockState#getSeed` and `BlockState#getOffset`
that are declared on `BlockBehaviour$BlockStateBase`, and constructors.