### PR TITLE
[1.21.9] Fix three startup crashes on Forge

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/mixin/ModelBlockRendererMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/ModelBlockRendererMixin.java
@@ -27,7 +27,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 public class ModelBlockRendererMixin {
 
     @ModifyExpressionValue(
-        method = "tesselateBlock(Lnet/minecraft/world/level/BlockAndTintGetter;Ljava/util/List;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Ljava/util/function/Function;ZI)V",
+        method = "tesselateBlock(Lnet/minecraft/world/level/BlockAndTintGetter;Ljava/util/List;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZI)V",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/block/state/BlockState;getOffset(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/Vec3;"

--- a/src/main/java/com/supermartijn642/fusion/mixin/SectionCompilerMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/SectionCompilerMixin.java
@@ -45,7 +45,7 @@ public class SectionCompilerMixin {
     }
 
     @ModifyExpressionValue(
-        method = "compile(Lnet/minecraft/core/SectionPos;Lnet/minecraft/client/renderer/chunk/RenderSectionRegion;Lcom/mojang/blaze3d/vertex/VertexSorting;Lnet/minecraft/client/renderer/SectionBufferBuilderPack;Ljava/util/List;)Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;",
+        method = "compile(Lnet/minecraft/core/SectionPos;Lnet/minecraft/client/renderer/chunk/RenderSectionRegion;Lcom/mojang/blaze3d/vertex/VertexSorting;Lnet/minecraft/client/renderer/SectionBufferBuilderPack;)Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;getBlockModel(Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/client/renderer/block/model/BlockStateModel;"


### PR DESCRIPTION
Same three fixes as #288, applied to this branch. The full reasoning, the crash output and the
verification are all in that pull request; this is the short version.

The Forge build of this branch cannot start. There are three causes, each hidden behind the
previous one:

1. **MixinExtras is declared for Jar-in-Jar but never bundled.** `jarJar.enable()` is never called,
   so the published jar has no `META-INF/jarjar` entries and every mixin using MixinExtras fails
   with a missing `LocalRef` class. Forge only ships MixinExtras itself from 60.0.16, which is
   Minecraft 1.21.10, so this branch has to bundle it.
2. **`ModelBlockRendererMixin` targets the NeoForge signature.** Forge patches `tesselateBlock` to
   take a `VertexConsumer` where vanilla and NeoForge take a `Function`.
3. **`SectionCompilerMixin` targets a parameter Forge does not have.** Forge's `compile` has no
   trailing `List` parameter.

Both descriptors were read with javap from the mapped Forge jar **for this branch specifically**
rather than copied across, since they are not identical on every version. On 1.21.5, for example,
`compile` takes a `RenderChunkRegion` where the later branches take a `RenderSectionRegion`.

## Testing

Built and tested in game on Minecraft 1.21.9, using a connected and emissive ore resource pack. The
game reaches the main menu, loads a world and renders correctly, with no errors in the log.