### PR TITLE
[1.21.11] Fix two startup crashes and a particle NPE on Forge

### DIFF
--- a/src/main/java/com/supermartijn642/fusion/mixin/ModelBlockRendererMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/ModelBlockRendererMixin.java
@@ -27,7 +27,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 public class ModelBlockRendererMixin {
 
     @ModifyExpressionValue(
-        method = "tesselateBlock(Lnet/minecraft/world/level/BlockAndTintGetter;Ljava/util/List;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Ljava/util/function/Function;ZI)V",
+        method = "tesselateBlock(Lnet/minecraft/world/level/BlockAndTintGetter;Ljava/util/List;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZI)V",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/block/state/BlockState;getOffset(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/Vec3;"

--- a/src/main/java/com/supermartijn642/fusion/mixin/SectionCompilerMixin.java
+++ b/src/main/java/com/supermartijn642/fusion/mixin/SectionCompilerMixin.java
@@ -45,7 +45,7 @@ public class SectionCompilerMixin {
     }
 
     @ModifyExpressionValue(
-        method = "compile(Lnet/minecraft/core/SectionPos;Lnet/minecraft/client/renderer/chunk/RenderSectionRegion;Lcom/mojang/blaze3d/vertex/VertexSorting;Lnet/minecraft/client/renderer/SectionBufferBuilderPack;Ljava/util/List;)Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;",
+        method = "compile(Lnet/minecraft/core/SectionPos;Lnet/minecraft/client/renderer/chunk/RenderSectionRegion;Lcom/mojang/blaze3d/vertex/VertexSorting;Lnet/minecraft/client/renderer/SectionBufferBuilderPack;)Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;getBlockModel(Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/client/renderer/block/model/BlockStateModel;"


### PR DESCRIPTION
The Forge build of this branch cannot start, and once it does it crashes on the first terrain
particle. Three separate causes, commit by commit.

Note this branch does **not** need the Jar-in-Jar change from #285. Forge began shipping
MixinExtras itself in 60.0.16 ("Introduce MixinExtras as an included, optional dependency", #10709),
so from 1.21.10 onwards it no longer has to be bundled. That is also why the older branches declare
a `jarJar` dependency and this one does not.

## 1. ModelBlockRendererMixin targets the NeoForge signature

```
Critical injection failure: @ModifyExpressionValue annotation on modifyRandomOffset
could not find any targets matching 'tesselateBlock(...Lcom/mojang/blaze3d/vertex/PoseStack;
Ljava/util/function/Function;ZI)V' in net/minecraft/client/renderer/block/ModelBlockRenderer
```

Forge patches that method to take a `VertexConsumer` where vanilla and NeoForge take a `Function`.
Verified with javap against the mapped Forge jar, which declares:

```
tesselateBlock(BlockAndTintGetter, List, BlockState, BlockPos, PoseStack, VertexConsumer, boolean, int)
```

The `forge-1.21`, `forge-1.21.2` and `forge-1.21.4` branches carry a Forge specific descriptor here.
From `forge-1.21.5` onwards this file is identical to the one on the matching NeoForge branch.

## 2. SectionCompilerMixin targets a parameter Forge does not have

```
Critical injection failure: @ModifyExpressionValue annotation on collectModelsByOffset
could not find any targets matching 'compile(...SectionBufferBuilderPack;Ljava/util/List;)
...SectionCompiler$Results;' in net/minecraft/client/renderer/chunk/SectionCompiler
```

Forge's `compile` has no trailing `List` parameter. The replacement descriptor is taken verbatim
from javap against the mapped Forge jar. This file is already Forge specific in its body, since it
imports `net.minecraftforge.client.model.data.ModelData`, so only the descriptor appears to have
been carried over.

The handler's `@Local` bindings are unaffected, checked against the local variable table of Forge's
method: the `List<BlockModelPart>` it captures is a local variable rather than a parameter, and the
`BlockPos` ordinal 2 and the two `Map` ordinals do not move.

## 3. NullPointerException in particleIcon on the first terrain particle

With the two above fixed the game starts and renders, then dies as soon as any terrain particle is
created, for example on the first sprint:

```
java.lang.NullPointerException: Cannot invoke
"net.minecraftforge.client.model.data.ModelData.get(...)" because "data" is null
  at ...model.modifiers.block.BlockModelModifierBakedModel.particleIcon(BlockModelModifierBakedModel.java:188)
  at net.minecraft.client.renderer.block.BlockModelShaper.getParticleIcon(BlockModelShaper.java:26)
  at net.minecraft.client.particle.TerrainParticle.updateSprite(TerrainParticle.java:108)
  ...
  at net.minecraft.world.entity.Entity.spawnSprintParticle(Entity.java:1645)
```

`BlockModelShaper#getParticleIcon` calls the Forge overload `particleIcon(ModelData)` with null, and
the parameter was dereferenced immediately. The fallback for a null render data result was already
two lines below, so the parameter guard lands in the same place, and the parameter annotation is
changed from `@NotNull` to `@Nullable` to match how vanilla actually calls it.

## Testing

Built and tested in game on Minecraft 1.21.11 with Forge 61.1.5, using a connected and emissive ore
resource pack. The game reaches the main menu, loads a world and renders correctly, with no errors
in the log.